### PR TITLE
Modular Asset Loader

### DIFF
--- a/App.config
+++ b/App.config
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <configuration>
     <startup> 
-        <supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.5.1"/>
+        <supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.5.2"/>
     </startup>
 </configuration>

--- a/RobustEngine.csproj
+++ b/RobustEngine.csproj
@@ -9,7 +9,7 @@
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>RobustEngine</RootNamespace>
     <AssemblyName>RobustEngine</AssemblyName>
-    <TargetFrameworkVersion>v4.5.1</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.5.2</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
     <AutoGenerateBindingRedirects>true</AutoGenerateBindingRedirects>
     <TargetFrameworkProfile />

--- a/RobustEngine.csproj
+++ b/RobustEngine.csproj
@@ -34,6 +34,15 @@
     <WarningLevel>4</WarningLevel>
   </PropertyGroup>
   <ItemGroup>
+    <Reference Include="glTFLoader, Version=1.0.0.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>packages\glTFLoader.1.0.0.3\lib\net452\glTFLoader.dll</HintPath>
+    </Reference>
+    <Reference Include="glTFLoader_Shared, Version=1.0.0.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>packages\glTFLoader.1.0.0.3\lib\net452\glTFLoader_Shared.dll</HintPath>
+    </Reference>
+    <Reference Include="Newtonsoft.Json, Version=7.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
+      <HintPath>packages\Newtonsoft.Json.7.0.1\lib\net45\Newtonsoft.Json.dll</HintPath>
+    </Reference>
     <Reference Include="OpenTK, Version=2.0.0.0, Culture=neutral, PublicKeyToken=bad199fe84eb3df4, processorArchitecture=MSIL">
       <HintPath>packages\OpenTK.2.0.0\lib\net20\OpenTK.dll</HintPath>
       <Private>True</Private>

--- a/System/AssetLoading/AssetLoader.cs
+++ b/System/AssetLoading/AssetLoader.cs
@@ -1,0 +1,51 @@
+﻿using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace RobustEngine.System.AssetLoading
+{
+    //stream providers are anything that can provide a data stream.  I only have hard drive file reading for now but this potentially could be streamed from the internet
+    interface IStreamProvider
+    {
+        Stream GetStream(string type, string name);
+    }
+
+    //type loaders convert the raw data stream to actual usable objects, with one per type of loaded asset
+    interface ITypeLoader
+    {
+        object Load(Stream stream);
+    }
+
+    class AssetLoader
+    {
+        IStreamProvider provider;
+        Dictionary<string, ITypeLoader> loaders = new Dictionary<string, ITypeLoader>();
+
+        public AssetLoader(IStreamProvider streamProvider)
+        {
+            provider = streamProvider;
+        }
+
+        object LoadAsset(string type, string name)
+        {
+            var loader = loaders[type];
+            var stream = provider.GetStream(type, name);
+
+            return loader.Load(stream);
+        }
+
+        public void RegisterType(string type, ITypeLoader loader)
+        {
+            loaders[type] = loader;
+        } 
+
+        //this means the default "missing asset" sprites, models, sound effects, etc. all need to be in their respective type folder named 'missing.<filetype>'
+        public static string GetMissingAssetDefault(string type)
+        {
+            return $"..\\..\\Content\\Assets\\{type}\\missing.*";
+        }
+    }
+}

--- a/System/AssetLoading/StreamProviders/DriveStreamProvider.cs
+++ b/System/AssetLoading/StreamProviders/DriveStreamProvider.cs
@@ -1,0 +1,38 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using System.IO;
+
+namespace RobustEngine.System.AssetLoading.StreamProviders
+{
+    class DriveStreamProvider : IStreamProvider
+    {
+        public Stream GetStream(string type, string key)
+        {
+            string targetFileDir = "";
+            Stream outStream;
+            var files = Directory.GetFiles($"..\\..\\..\\Content\\Assets\\{type}", $"{key}.*", SearchOption.AllDirectories);
+            //If the resulting length of files array is 1, that means that it found the file it wanted
+            if (files.Length == 1)
+            {
+                targetFileDir = files[0];
+            } else if (files.Length == 0) //If it's 0, it didn't, so get the missing asset
+            {
+                targetFileDir = AssetLoader.GetMissingAssetDefault(type);
+            } else //If something else happened, it's fucked
+            {
+                //error here?
+            }
+            try
+            {
+                outStream = File.OpenRead(targetFileDir);
+            } catch(FileNotFoundException e)
+            {
+                outStream = File.OpenRead(AssetLoader.GetMissingAssetDefault(type));;
+            }
+            return outStream;
+        }
+    }
+}

--- a/System/AssetLoading/TypeLoaders/GltfTypeLoader.cs
+++ b/System/AssetLoading/TypeLoaders/GltfTypeLoader.cs
@@ -1,0 +1,86 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using System.IO;
+using System.Runtime.Remoting.Messaging;
+using glTFLoader.Schema;
+using Newtonsoft.Json;
+
+namespace RobustEngine.System.AssetLoading.TypeLoaders
+{
+    class GltfTypeLoader : ITypeLoader
+    {
+        const uint GLTF = 0x46546C67;
+        const uint JSON = 0x4E4F534A;
+
+        //This shit is complicated and 90% ripped off from the loader interface to take a stream instead of a path
+        public object Load(Stream stream)
+        {
+            bool binaryFile = false;
+
+            using (BinaryReader binaryReader = new BinaryReader(stream))
+            {
+                uint magic = binaryReader.ReadUInt32();
+                if (magic == GLTF)
+                {
+                    binaryFile = true;
+                }
+            }
+
+            string fileData;
+            if(binaryFile)
+            {
+                fileData = parseBinary(stream);
+            } else
+            {
+                fileData = parseTextStream(stream);
+            }
+            return JsonConvert.DeserializeObject<Gltf>(fileData);
+        }
+
+        private string parseTextStream(Stream stream)
+        {
+            MemoryStream ms = new MemoryStream();
+            stream.CopyTo(ms);
+            var byteArray = ms.ToArray();
+            return Encoding.UTF8.GetString(byteArray);
+        }
+
+        private string parseBinary(Stream stream)
+        {
+            using (BinaryReader binaryReader = new BinaryReader(stream))
+            {
+                uint magic = binaryReader.ReadUInt32();
+                if (magic != GLTF)
+                {
+                    throw new InvalidDataException($"Unexpected magic number: {magic}");
+                }
+
+                uint version = binaryReader.ReadUInt32();
+                if (version != 2)
+                {
+                    throw new NotImplementedException($"Unkown Version Number: {version}");
+                }
+
+                uint length = binaryReader.ReadUInt32();
+                var fs = (FileStream)stream;
+                long fileLength = new FileInfo(fs.Name).Length;
+                if(length != fileLength)
+                {
+                    throw new InvalidDataException($"The specified length of the file {length} is not equal to the length of the file {fileLength}");
+                }
+
+                uint chunkLength = binaryReader.ReadUInt32();
+                uint chunkFormat = binaryReader.ReadUInt32();
+                if(chunkFormat != JSON)
+                {
+                    throw new NotImplementedException($"The first chunk must be format 'JSON': {chunkFormat}");
+                }
+
+                return Encoding.UTF8.GetString(binaryReader.ReadBytes((int)chunkLength));
+            }
+        }
+    }
+}

--- a/packages.config
+++ b/packages.config
@@ -1,4 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
+  <package id="glTFLoader" version="1.0.0.3" targetFramework="net452" />
+  <package id="Newtonsoft.Json" version="7.0.1" targetFramework="net452" />
   <package id="OpenTK" version="2.0.0" targetFramework="net451" />
 </packages>


### PR DESCRIPTION
An asset loader that could theoretically load anything with the same function.
It's fully modular to both abstract out the file loader and data upstream, so while it currently only features GLTF loading from hard drive, it could be expanded to also load png images, audio files, fonts, etc.  It could also be expanded to get it's data upstream from a completely different source, such as streaming directly from a server.

Only thing changed besides the addition of it is that the .net version was changed from 4.5.1 to 4.5.2.  This didn't cause any problems as far as I can tell.